### PR TITLE
Update to support latest gnome-shell versions

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -3,5 +3,5 @@
     "name": "Simple Name",
     "description": "Display the user name in the top menu.",
     "url": "https://github.com/rmariano/SimpleName",
-    "shell-version": ["3.10.4", "3.12", "3.14", "3.16", "3.18", "3.20", "3.22"]
+    "shell-version": ["3.10.4", "3.12", "3.14", "3.16", "3.18", "3.20", "3.22", "3.24", "3.26", "3.28", "3.30", "3.32"]
 }


### PR DESCRIPTION
 * This extension not support latest gnome-shell versions.
 * This commit update metadata.json to support latest gnome-shell versions.
 * It is works from gnome-shell 3.30.

Signed-off-by: Yang Jeong Hun <onyxclover9931@gmail.com>